### PR TITLE
3061407: Can't switch to next material

### DIFF
--- a/src/Entity/CourseEnrollment.php
+++ b/src/Entity/CourseEnrollment.php
@@ -124,14 +124,14 @@ class CourseEnrollment extends ContentEntityBase implements CourseEnrollmentInte
    * {@inheritdoc}
    */
   public function getCourse() {
-    return $this->get('cid')->entity;
+    return $this->get('gid')->entity;
   }
 
   /**
    * {@inheritdoc}
    */
   public function getCourseId() {
-    return $this->get('cid')->target_id;
+    return $this->get('gid')->target_id;
   }
 
   /**


### PR DESCRIPTION
## Problem
When I try to go to the next material then I see the following error:
```
The website encountered an unexpected error. Please try again later.</br></br><em class="placeholder">Drupal\Core\Entity\EntityStorageException</em>: Field cid is unknown. in <em class="placeholder">Drupal\Core\Entity\Sql\SqlContentEntityStorage-&gt;save()</em> (line <em class="placeholder">783</em> of <em class="placeholder">core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php</em>). <pre class="backtrace">Drupal\Core\Entity\ContentEntityBase-&gt;get(&#039;cid&#039;) (Line: 127)
Drupal\social_course\Entity\CourseEnrollment-&gt;getCourse() (Line: 93)
social_badge_course_enrollment_update(Object)
call_user_func_array(&#039;social_badge_course_enrollment_update&#039;, Array) (Line: 403)
Drupal\Core\Extension\ModuleHandler-&gt;invokeAll(&#039;course_enrollment_update&#039;, Array) (Line: 204)
Drupal\Core\Entity\EntityStorageBase-&gt;invokeHook(&#039;update&#039;, Object) (Line: 773)
Drupal\Core\Entity\ContentEntityStorageBase-&gt;invokeHook(&#039;update&#039;, Object) (Line: 507)
Drupal\Core\Entity\EntityStorageBase-&gt;doPostSave(Object, 1) (Line: 658)
Drupal\Core\Entity\ContentEntityStorageBase-&gt;doPostSave(Object, 1) (Line: 432)
Drupal\Core\Entity\EntityStorageBase-&gt;save(Object) (Line: 774)
Drupal\Core\Entity\Sql\SqlContentEntityStorage-&gt;save(Object) (Line: 390)
Drupal\Core\Entity\Entity-&gt;save() (Line: 163)
Drupal\social_course\Controller\CoursesController-&gt;nextMaterial(Object, Object)
call_user_func_array(Array, Array) (Line: 123)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber-&gt;Drupal\Core\EventSubscriber\{closure}() (Line: 582)
Drupal\Core\Render\Renderer-&gt;executeInRenderContext(Object, Object) (Line: 124)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber-&gt;wrapControllerExecutionInRenderContext(Array, Array) (Line: 97)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber-&gt;Drupal\Core\EventSubscriber\{closure}() (Line: 151)
Symfony\Component\HttpKernel\HttpKernel-&gt;handleRaw(Object, 1) (Line: 68)
Symfony\Component\HttpKernel\HttpKernel-&gt;handle(Object, 1, 1) (Line: 57)
Drupal\Core\StackMiddleware\Session-&gt;handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\KernelPreHandle-&gt;handle(Object, 1, 1) (Line: 99)
Drupal\page_cache\StackMiddleware\PageCache-&gt;pass(Object, 1, 1) (Line: 78)
Drupal\page_cache\StackMiddleware\PageCache-&gt;handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware-&gt;handle(Object, 1, 1) (Line: 52)
Drupal\Core\StackMiddleware\NegotiationMiddleware-&gt;handle(Object, 1, 1) (Line: 23)
Stack\StackedHttpKernel-&gt;handle(Object, 1, 1) (Line: 693)
Drupal\Core\DrupalKernel-&gt;handle(Object) (Line: 19)
</pre>
```

## Solution
Use correct field name in methods for getting a course of current course enrollment entity.

## Issue tracker
- https://www.drupal.org/project/social_course/issues/3061407
- https://jira.goalgorilla.com/browse/CTBTO-21

## How to test
- [x] Log in as a normal member.
- [x] Open any course and enroll.
- [x] Open the first section and try to switch to the next material via pager.

## Release notes
Use correct field name in methods for getting a course of current course enrollment entity.