### PR TITLE
Issue #3075344 by ribel: Update dependency from Video Embed Field to version 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "drupal/paragraphs": "^1.2",
         "drupal/inline_entity_form": "^1.0@beta",
-        "drupal/video_embed_field": "^1.5",
+        "drupal/video_embed_field": "^2.2",
         "drupal/weight": "^3.0"
     }
 }


### PR DESCRIPTION
**Problem**
I am not able to use social_course on a project, which already uses newer version of video_embed_field module.

```
Problem 1
    - Can only install one of: drupal/video_embed_field[2.2.0, 1.x-dev].
    - Can only install one of: drupal/video_embed_field[1.x-dev, 2.2.0].
    - Can only install one of: drupal/video_embed_field[1.x-dev, 2.2.0].
    - drupal/social_course 2.x-dev requires drupal/video_embed_field ^1.5 -> satisfiable by drupal/video_embed_field[1.x-dev].
    - Installation request for drupal/social_course ^2.0 -> satisfiable by drupal/social_course[2.x-dev].
    - Installation request for drupal/video_embed_field (locked at 2.2.0, required as ^2.0) -> satisfiable by drupal/video_embed_field[2.2.0]. 
```

**Solution**
Update dependency from `video_embed_field` in `composer.json` to version `2.x`

**Issue tracker**
- https://www.drupal.org/project/social_course/issues/3075344