### PR TITLE
Issue #3092543 by chmez: The "All" search tab without results

### DIFF
--- a/social_course.module
+++ b/social_course.module
@@ -1663,20 +1663,40 @@ function social_course_search_api_query_alter(QueryInterface &$query) {
   }
 
   if ($account->hasPermission('view own unpublished groups')) {
+    $found = FALSE;
+
     // Search of field for group owner ID.
     foreach ($fields as $user_field => $field) {
       if ($field->getPropertyPath() === 'uid' && $field->getDatasourceId() === 'entity:group') {
-        $query->addConditionGroup(
-          $query->createConditionGroup('OR')
-            ->addCondition($status_field, TRUE)
-            ->addCondition($user_field, $account->id())
-        );
+        $found = TRUE;
+        break;
       }
     }
+
+    if (!$found) {
+      return;
+    }
+  }
+
+  $condition_group = $query->createConditionGroup('AND')
+    ->addCondition('search_api_datasource', 'entity:group');
+
+  if (isset($user_field)) {
+    $condition_group->addConditionGroup(
+      $query->createConditionGroup('OR')
+        ->addCondition($status_field, TRUE)
+        ->addCondition($user_field, $account->id())
+    );
   }
   else {
-    $query->addCondition($status_field, TRUE);
+    $condition_group->addCondition($status_field, TRUE);
   }
+
+  $query->addConditionGroup(
+    $query->createConditionGroup('OR')
+      ->addConditionGroup($condition_group)
+      ->addCondition('search_api_datasource', 'entity:group', '<>')
+  );
 }
 
 /**

--- a/social_course.module
+++ b/social_course.module
@@ -1673,6 +1673,8 @@ function social_course_search_api_query_alter(QueryInterface &$query) {
       }
     }
 
+    // Allow seeing only the published group when the search index does not
+    // contain a field for the owner of the group.
     if (!$found) {
       return;
     }
@@ -1682,6 +1684,8 @@ function social_course_search_api_query_alter(QueryInterface &$query) {
     ->addCondition('search_api_datasource', 'entity:group');
 
   if (isset($user_field)) {
+    // Add own unpublished groups to search results when the search index
+    // contains a field for the owner of the group.
     $condition_group->addConditionGroup(
       $query->createConditionGroup('OR')
         ->addCondition($status_field, TRUE)
@@ -1689,6 +1693,9 @@ function social_course_search_api_query_alter(QueryInterface &$query) {
     );
   }
   else {
+    // Select only published groups because the search index does not contain a
+    // field for the owner of the group so own groups can not be linked to the
+    // current user.
     $condition_group->addCondition($status_field, TRUE);
   }
 


### PR DESCRIPTION
## Problem
The current user can not see nodes on the "All" search tab when the user using the search phrase and the user doesn't have access to viewing unpublished courses.

## Solution
Add checking to search query if the current entity is a group.

## Issue tracker
- https://www.drupal.org/project/social_course/issues/3092543
- https://getopensocial.atlassian.net/browse/YANG-1755

## How to test
- [ ] Log in as **CM+**.
- [ ] Create the **Search tab without results** topic but don't attach it to any group.
- [ ] Log in as **member**.
- [ ] Click on zoom-icon and fill in the search field with **results**.
- [ ] When you press zoom-icon then you should see the **Search tab without results** topic in the search results on the **All** search tab.

## Release notes
Functionality for viewing own unpublished courses shouldn't hide content (topics, events, etc) in the search results.