### PR TITLE
Issue #3094418 by sjoerdvandervis: Add ConfigOverride for manage members tab

### DIFF
--- a/modules/social_course_advanced/social_course_advanced.services.yml
+++ b/modules/social_course_advanced/social_course_advanced.services.yml
@@ -1,5 +1,5 @@
 services:
   social_course_advanced.overrider:
-    class: Drupal\social_course_basic\SocialCourseAdvancedOverrides
+    class: Drupal\social_course_advanced\SocialCourseAdvancedOverrides
     tags:
       - { name: config.factory.override, priority: 5 }

--- a/modules/social_course_advanced/social_course_advanced.services.yml
+++ b/modules/social_course_advanced/social_course_advanced.services.yml
@@ -1,0 +1,5 @@
+services:
+  social_course_advanced.overrider:
+    class: Drupal\social_course_basic\SocialCourseAdvancedOverrides
+    tags:
+      - { name: config.factory.override, priority: 5 }

--- a/modules/social_course_advanced/src/SocialCourseAdvancedOverrides.php
+++ b/modules/social_course_advanced/src/SocialCourseAdvancedOverrides.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\social_course_advanced;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * Class SocialCourseAdvancedOverrides.
+ */
+class SocialCourseAdvancedOverrides implements ConfigFactoryOverrideInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+
+    $config_name = 'views.view.group_manage_members';
+
+    if (in_array($config_name, $names)) {
+      $overrides[$config_name] = [
+        'display' => [
+          'default' => [
+            'display_options' => [
+              'filters' => [
+                'type' => [
+                  'value' => [
+                    'course_advanced-group_membership' => 'course_advanced-group_membership',
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ];
+    }
+
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'SocialCourseAdvancedOverrider';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}

--- a/modules/social_course_basic/social_course_basic.services.yml
+++ b/modules/social_course_basic/social_course_basic.services.yml
@@ -1,0 +1,5 @@
+services:
+  social_course_basic.overrider:
+    class: Drupal\social_course_basic\SocialCourseBasicOverrides
+    tags:
+      - { name: config.factory.override, priority: 5 }

--- a/modules/social_course_basic/src/SocialCourseBasicOverrides.php
+++ b/modules/social_course_basic/src/SocialCourseBasicOverrides.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\social_course_basic;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * Class SocialCourseBasicOverrides.
+ */
+class SocialCourseBasicOverrides implements ConfigFactoryOverrideInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+
+    $config_name = 'views.view.group_manage_members';
+
+    if (in_array($config_name, $names)) {
+      $overrides[$config_name] = [
+        'display' => [
+          'default' => [
+            'display_options' => [
+              'filters' => [
+                'type' => [
+                  'value' => [
+                    'course_basic-group_membership' => 'course_basic-group_membership',
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ];
+    }
+
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'SocialCourseBasicOverrider';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}

--- a/src/SocialCourseOverrides.php
+++ b/src/SocialCourseOverrides.php
@@ -514,30 +514,6 @@ class SocialCourseOverrides implements ConfigFactoryOverrideInterface {
       ];
     }
 
-    $config_name = 'views.view.group_manage_members';
-
-    if (in_array($config_name, $names)) {
-      $overrides[$config_name] = [
-        'display' => [
-          'default' => [
-            'display_options' => [
-              'filters' => [
-                'type' => [
-                  'value' => [
-                    'closed_group-group_membership' => 'closed_group-group_membership',
-                    'open_group-group_membership' => 'open_group-group_membership',
-                    'public_group-group_membership' => 'public_group-group_membership',
-                    'course_basic-group_membership' => 'course_basic-group_membership',
-                    'course_advanced-group_membership' => 'course_advanced-group_membership',
-                  ],
-                ],
-              ],
-            ],
-          ],
-        ],
-      ];
-    }
-
     $config_name = 'block.block.views_block__group_managers_block_list_managers';
 
     if (in_array($config_name, $names)) {

--- a/src/SocialCourseOverrides.php
+++ b/src/SocialCourseOverrides.php
@@ -514,6 +514,30 @@ class SocialCourseOverrides implements ConfigFactoryOverrideInterface {
       ];
     }
 
+    $config_name = 'views.view.group_manage_members';
+
+    if (in_array($config_name, $names)) {
+      $overrides[$config_name] = [
+        'display' => [
+          'default' => [
+            'display_options' => [
+              'filters' => [
+                'type' => [
+                  'value' => [
+                    'closed_group-group_membership' => 'closed_group-group_membership',
+                    'open_group-group_membership' => 'open_group-group_membership',
+                    'public_group-group_membership' => 'public_group-group_membership',
+                    'course_basic-group_membership' => 'course_basic-group_membership',
+                    'course_advanced-group_membership' => 'course_advanced-group_membership',
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ];
+    }
+
     $config_name = 'block.block.views_block__group_managers_block_list_managers';
 
     if (in_array($config_name, $names)) {


### PR DESCRIPTION
## Problem
For Course leader+, it is not possible to manage the members at the moment, as the tab always shows that there are no members yet.

## Solution
Add a ConfigOverride to social_course module to also show the manage group members view for  course_basic and course_advanced.

## Issue tracker
- https://www.drupal.org/project/social_course/issues/3094418
- https://getopensocial.atlassian.net/browse/TB-2450

## How to test
- [ ] Log in as **Course leader+**.
- [ ] Check a course and go to the "Manage members" tab.
- [ ] See that you can edit the members that are enrolled to a course and that you can elevate their rights to be a course leader.