### PR TITLE
Issue #3096888 by SV: Member can skip last quiz section in the course

### DIFF
--- a/src/Controller/CoursesController.php
+++ b/src/Controller/CoursesController.php
@@ -237,6 +237,15 @@ class CoursesController extends ControllerBase {
         // Redirect to the next section when it exists and not marked as
         // completed.
         elseif ($finish_section) {
+          // Cleanup related entity of "next section".
+          $course_enrollment = $storage->loadByProperties([
+            'gid' => $group->id(),
+            'sid' => $next_section->id(),
+            'uid' => $account->id(),
+          ]);
+          if ($course_enrollment) {
+            $storage->delete($course_enrollment);
+          }
           $response = self::nextMaterial($group, $next_section);
         }
         // Redirect to next step even if the next step was completed but current


### PR DESCRIPTION
## Problem
When the user goes to the last section with quiz, he could actually return back to the previous section. After this action the user proceeds to the last again and now a quiz from this section marks as done and section is finished. The user receives a badge without completing the course but it shouldn't be.

## Solution
Cleanup related course enrollment entity for "next" section

## Issue tracker
- https://www.drupal.org/project/social_course/issues/3096888
- https://getopensocial.atlassian.net/browse/YANG-1850
