### PR TITLE
Issues #3104081: Removed strict check parameter of array_search to not check the types of arguments.

### DIFF
--- a/social_course.module
+++ b/social_course.module
@@ -1548,7 +1548,7 @@ function social_course_remove_material_from_courses(int $material_id): void {
     /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $section_content */
     $materials = $section_content->getValue();
     // Find the index of the material in this field.
-    $idx = array_search($material_id, array_column($materials, 'target_id'), TRUE);
+    $idx = array_search($material_id, array_column($materials, 'target_id'));
     $section_content->removeItem($idx);
 
     $section->save();


### PR DESCRIPTION
## Problem
User is unable to remove any section from the existing course.

## Solution
Remove the third parameter at https://github.com/goalgorilla/social_course/blob/8.x-2.x/social_course.module#L1551

## Issue tracker
- https://www.drupal.org/project/social_course/issues/3104081
- https://getopensocial.atlassian.net/browse/TB-3587
