### PR TITLE
Issue #3118921 by Makishima: Allow an enrolled user to start any sections in a non-sequential course

### DIFF
--- a/src/CourseWrapper.php
+++ b/src/CourseWrapper.php
@@ -194,6 +194,8 @@ class CourseWrapper implements CourseWrapperInterface {
         // Allow start first section if user has not started course yet.
         $section = current($sections);
         $access = $access->orIf(AccessResult::allowedIf($section->id() == $node->id() && !$section->get('field_course_section_content')->isEmpty()));
+        // Allow starting sections for a non-sequential course.
+        $access = $access->orIf(AccessResult::allowedIf(!$this->courseIsSequential()));
         break;
 
       case 'bypass':


### PR DESCRIPTION
## Problem
An issue with access to sections for non-sequential courses. Only the first section is available  for enrolled member, but all sections should be available.

## Solution
Fix the sectionAccess function, add a condition for a non-sequential course.

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-1750
Drupal.org: https://www.drupal.org/project/social_course/issues/3118921

## How to test
- [ ] Create a non-sequential course
- [ ] Create a sections in this course
- [ ] Login as a member, enroll to the course
- [ ] Make sure all sections are available for starting on the course sections page
