### PR TITLE
Issue #3118925 by ribel: Remove duplicated core.entity_view_mode.paragraph.preview from social_course configs, since it also exists in paragraphs module

### DIFF
--- a/config/install/core.entity_view_mode.paragraph.preview.yml
+++ b/config/install/core.entity_view_mode.paragraph.preview.yml
@@ -1,9 +1,0 @@
-langcode: en
-status: true
-dependencies:
-  module:
-    - paragraphs
-id: paragraph.preview
-label: Preview
-targetEntityType: paragraph
-cache: true


### PR DESCRIPTION
### Problem
During installation after update to Open Social 8.x I see the error:

```
Configuration objects     [error]
(core.entity_view_mode.paragraph.preview) provided by social_course
already exist in active configuration
This config file also exists in Paragraphs module.
```

### Solution
Remove `core.entity_view_mode.paragraph.preview` from `social_course` configs.

### Issue tracker

- https://www.drupal.org/project/social_course/issues/3118925