### PR TITLE
Issue #3171498 by agami4: Add title to edit content svg icon on the course pages

### DIFF
--- a/templates/group--course-basic--hero.html.twig
+++ b/templates/group--course-basic--hero.html.twig
@@ -14,7 +14,8 @@ group_hero_styled_image_url ? 'cover-img cover-img-gradient',
     {% if group_edit_url %}
         <div class="hero-action-button">
             <a href="{{ group_edit_url }}"  title="Edit group" class="btn btn-default btn-floating waves-effect waves-circle">
-                <svg class="icon-gray icon-medium">
+              <title>{% trans %}Edit content{% endtrans %}</title>
+              <svg class="icon-gray icon-medium">
                     <use xlink:href="#icon-edit"></use>
                 </svg>
             </a>

--- a/templates/group--course-basic--hero.html.twig
+++ b/templates/group--course-basic--hero.html.twig
@@ -13,8 +13,8 @@ group_hero_styled_image_url ? 'cover-img cover-img-gradient',
 <div{{ attributes.addClass(cover_classes) }} {% if group_hero_styled_image_url %} style="background-image: url('{{ group_hero_styled_image_url }}');" {% endif %}>
     {% if group_edit_url %}
         <div class="hero-action-button">
-            <a href="{{ group_edit_url }}"  title="Edit group" class="btn btn-default btn-floating waves-effect waves-circle">
-              <title>{% trans %}Edit content{% endtrans %}</title>
+            <a href="{{ group_edit_url }}"  title="{% trans %}Edit group{% endtrans %}" class="btn btn-default btn-floating waves-effect waves-circle">
+              <title>{% trans %}Edit group{% endtrans %}</title>
               <svg class="icon-gray icon-medium">
                     <use xlink:href="#icon-edit"></use>
                 </svg>


### PR DESCRIPTION
## Problem
The pencil edit button that's displayed in the hero contains an SVG element that does not contain an alternative text or title element, this means the edit button is not accessible for screen readers.

## Solution
Add the required alternative or title text to the SVG.

## Issue tracker
https://www.drupal.org/project/social/issues/3171498

## How to test
- [ ] Open the inspector element and check if this SVG icon has a title attribute

## Release notes
The 'edit content' button has a title attribute.
