### PR TITLE
Issue #3171512 by agami4: Add title to SVG elements for the course teasers

### DIFF
--- a/templates/group--course-basic--featured.html.twig
+++ b/templates/group--course-basic--featured.html.twig
@@ -15,6 +15,7 @@
 {% block card_teaser_type %}
   <div class="teaser__teaser-type">
     <svg class="teaser__teaser-type-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+      <title>{{ label }}</title>
       <path d="M0 0h24v24H0z" fill="none"/>
       <path d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"/>
     </svg>

--- a/templates/group--course-basic--featured.html.twig
+++ b/templates/group--course-basic--featured.html.twig
@@ -15,7 +15,6 @@
 {% block card_teaser_type %}
   <div class="teaser__teaser-type">
     <svg class="teaser__teaser-type-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-      <title>{{ label }}</title>
       <path d="M0 0h24v24H0z" fill="none"/>
       <path d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"/>
     </svg>
@@ -29,16 +28,20 @@
         <path d="M3.5 18.49l6-6.01 4 4L22 6.92l-1.41-1.41-7.09 7.97-4-4L2 16.99z"/>
         <path fill="none" d="M0 0h24v24H0z"/>
       </svg>
-      <div class="teaser__content-text">{{ finished_sections }} / {{ course_sections }} {% trans %}sections completed{% endtrans %}</div>
+      <div class="teaser__content-text">
+        <span class="sr-only">{% trans %}Status course section{% endtrans %}</span>
+        {{ finished_sections }} / {{ course_sections }} {% trans %}sections completed{% endtrans %}
+      </div>
     </div>
 
   </small>
   <div>
     <div class="badge teaser__badge" title="{% trans %}The visibility of this content is set to community{% endtrans %}">
-      <svg class="badge__icon">
+      <svg class="badge__icon" aria-hidden="true">
         <use xlink:href="#icon-community"></use>
       </svg>
     </div>
+    <span class="sr-only">{% trans %}The visibility of this content is set to community{% endtrans %}</span>
     {% if course_status == 'enrolled' %}
       <span class="badge badge-start teaser__badge badge--section-not-started">
               {% trans %}You have enrolled{% endtrans %}


### PR DESCRIPTION
## Problem
Teasers use icons to convey the meaning of values that are shown. These icons do not have alternative labels so it's unclear for users using assistive technology (e.g. screen readers) what information they're being read.

## Solution
Add the title to SVG elements for all type of the teasers

## Issue tracker
https://www.drupal.org/project/social/issues/3171512

## How to test
- [ ] Go to the landing page and create a featured content block with all teasers.
- [ ] Using a screenreader (e.g. VoiceOver on Mac or NVDA on Windows)
- [ ] Navigate to the featured content
- [ ] Verify that it's clear for a screen reader user what title of the icon they've selected (e.g. Topic, Discussion, Group)

## Screenshots
-

## Release notes
Featured content on landing pages should now be easier to navigate using a screenreader. The information conveyed in teasers has a clear title.

## Change Record
-

## Translations
-
