### PR TITLE
by robertragas: remove config override in favor of a update hook

### DIFF
--- a/social_course.install
+++ b/social_course.install
@@ -328,7 +328,7 @@ function social_course_update_8007() {
 }
 
 /**
- * Show profile hero block on My discussions page
+ * Show profile hero block on My courses page
  */
 function social_course_update_8008() {
   $config_name = 'block.block.socialblue_profile_hero_block';

--- a/social_course.install
+++ b/social_course.install
@@ -326,3 +326,18 @@ function social_course_update_8007() {
     }
   }
 }
+
+/**
+ * Show profile hero block on My discussions page
+ */
+function social_course_update_8008() {
+  $config_name = 'block.block.socialblue_profile_hero_block';
+  $config = \Drupal::service('config.factory')->getEditable($config_name);
+  if (!empty($config->getRawData())) {
+    $pages = $config->get('visibility.request_path.pages');
+    $pages .= "\r\n/user/*/courses";
+    $config->set('visibility.request_path.pages', $pages);
+    $config->save();
+  }
+}
+

--- a/src/SocialCourseOverrides.php
+++ b/src/SocialCourseOverrides.php
@@ -530,22 +530,6 @@ class SocialCourseOverrides implements ConfigFactoryOverrideInterface {
       ];
     }
 
-    // Show profile hero block on My Courses page.
-    $config_name = 'block.block.socialblue_profile_hero_block';
-
-    if (in_array($config_name, $names)) {
-      $config = \Drupal::service('config.factory')->getEditable($config_name);
-      $pages = $config->get('visibility.request_path.pages');
-      $pages .= "\r\n/user/*/courses";
-      $overrides[$config_name] = [
-        'visibility' => [
-          'request_path' => [
-            'pages' => $pages,
-          ],
-        ],
-      ];
-    }
-
     // Add Basic and Advanced Courses to related courses field settings.
     $config_names = [
       'field.field.group.course_advanced.field_course_related_courses',


### PR DESCRIPTION
**Problem**
We use a lot of config overrides, including to show the hero on the my courses. A problem with the config overrides is that the page visibility doesn't override correctly, so if another module also overrides the same config override with extra paths it will only pick one of the overrides.

**Solution**
Now that we don't depend on features anymore we can just update the config itself and add the path there. This way we can also delete the config override.

**HTT**
1. drush updb
2. go to the my courses profile page
3. See the hero displaying