### PR TITLE
by robertragas: show profile block on courses and hide page title

### DIFF
--- a/social_course.install
+++ b/social_course.install
@@ -345,26 +345,18 @@ function social_course_update_8008() {
  * Hide page title block from the user courses profile.
  */
 function social_course_update_8009() {
-  $config_name = 'block.block.socialblue_pagetitleblock_content';
-  $config = \Drupal::service('config.factory')->getEditable($config_name);
-  if (!empty($config->getRawData())) {
-    $pages = $config->get('visibility.request_path.pages');
-    $pages .= "\r\n/user/*/courses";
-    $config->set('visibility.request_path.pages', $pages);
-    $config->save();
+  $configFactory = \Drupal::service('config.factory');
+  $config_names = [
+    'block.block.socialblue_pagetitleblock_content',
+    'block.block.socialblue_profile_statistic_block',
+  ];
+  foreach ($config_names as $config_name) {
+    $config = $configFactory->getEditable($config_name);
+    if (!empty($config->getRawData())) {
+      $pages = sprintf("%s\r\n/user/*/courses", $config->get('visibility.request_path.pages'));
+      $config->set('visibility.request_path.pages', $pages);
+      $config->save();
+    }
   }
 }
 
-/**
- * Configuration update: set profile block on course profile page.
- */
-function social_course_update_8010() {
-  $config_name = 'block.block.socialblue_profile_statistic_block';
-  $config = \Drupal::service('config.factory')->getEditable($config_name);
-  if (!empty($config->getRawData())) {
-    $pages = $config->get('visibility.request_path.pages');
-    $pages .= "\r\n/user/*/courses";
-    $config->set('visibility.request_path.pages', $pages);
-    $config->save();
-  }
-}

--- a/social_course.install
+++ b/social_course.install
@@ -341,3 +341,30 @@ function social_course_update_8008() {
   }
 }
 
+/**
+ * Hide page title block from the user courses profile.
+ */
+function social_course_update_8009() {
+  $config_name = 'block.block.socialblue_pagetitleblock_content';
+  $config = \Drupal::service('config.factory')->getEditable($config_name);
+  if (!empty($config->getRawData())) {
+    $pages = $config->get('visibility.request_path.pages');
+    $pages .= "\r\n/user/*/courses";
+    $config->set('visibility.request_path.pages', $pages);
+    $config->save();
+  }
+}
+
+/**
+ * Configuration update: set profile block on course profile page.
+ */
+function social_course_update_8010() {
+  $config_name = 'block.block.socialblue_profile_statistic_block';
+  $config = \Drupal::service('config.factory')->getEditable($config_name);
+  if (!empty($config->getRawData())) {
+    $pages = $config->get('visibility.request_path.pages');
+    $pages .= "\r\n/user/*/courses";
+    $config->set('visibility.request_path.pages', $pages);
+    $config->save();
+  }
+}


### PR DESCRIPTION
…file page

## Problem
When going to the courses page on the user profile page it does not show the profile statistics block so it leaves a big gap there.

## Solution
Add the courses profile page url to the block settings. 

## Issue tracker
https://www.drupal.org/project/social/issues/3181791

## How to test
- [ ] Enable social_courses
- [ ] Create a course and enroll to it
- [ ] Go to your user profile and click on courses tab
- [ ] See the profile block missing
- [ ] See the alignment incorrect
- [ ] Check out to this branch and check again

## Release notes
When Social Courses has been enabled it add an extra page on your profile to see your courses. This page was missing the profile block on the left which has been added now.