### PR TITLE
Issue #3191358 by mdeny: Add information to the course hero when course is finished

### DIFF
--- a/templates/group--course-basic--hero--sky.html.twig
+++ b/templates/group--course-basic--hero--sky.html.twig
@@ -12,6 +12,14 @@
         {{ content.field_course_type }}
       </div>
     {% endif %}
+    {% if course_status == 'finished' %}
+      <div class="badge badge-success">
+        {{ 'You have finished.'|t }}
+        {% if certificate_link %}
+          {{ certificate_link }}
+        {% endif %}
+      </div>
+    {% endif %}
     <div class="group-hero--wrapper">
       <h1>{{ content.label }}</h1>
     </div>


### PR DESCRIPTION
## Problem
As a user I want to see information in course hero that I've finished course successfully

## Solution
Add information to the course hero when course is finished

## Issue tracker
https://getopensocial.atlassian.net/browse/YANG-4510
https://www.drupal.org/project/social_course/issues/3191358

## How to test
- [ ] Go to the course
- [ ] Finish it successfully
- [ ] You should see text "You have finished" in course hero

## Link to the Prototype
https://www.figma.com/proto/eFn9UYCaSnerZgx9vxsmbR/Open-Social-Design-System?node-id=4949%3A1&viewport=-2717%2C801%2C1&scaling=min-zoom