### PR TITLE
Issue #3200126 by Ressinel: Improve UX of course creation form in order to match changes for groups in OS 10.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
         "drupal/paragraphs": "^1.2",
         "drupal/inline_entity_form": "^1.0@beta",
         "drupal/video_embed_field": "^1.5",
-        "drupal/weight": "^3.0"
+        "drupal/weight": "^3.0",
+        "goalgorilla/open_social": ">=10.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,10 @@
         "drupal/paragraphs": "^1.2",
         "drupal/inline_entity_form": "^1.0@beta",
         "drupal/video_embed_field": "^1.5",
-        "drupal/weight": "^3.0",
-        "goalgorilla/open_social": ">=10.0"
+        "drupal/weight": "^3.0"
+    },
+    "conflict": {
+        "goalgorilla/open_social": "<10.1",
+        "drupal/social": "<10.1"
     }
 }

--- a/config/install/core.entity_form_display.node.course_section.default.yml
+++ b/config/install/core.entity_form_display.node.course_section.default.yml
@@ -124,4 +124,3 @@ hidden:
   promote: true
   social_tagging: true
   sticky: true
-  uid: true

--- a/config/install/core.entity_form_display.node.course_section.default.yml
+++ b/config/install/core.entity_form_display.node.course_section.default.yml
@@ -32,8 +32,36 @@ third_party_settings:
         required_fields: true
         id: ''
         classes: ''
-      label: Information
+      label: 'Basic information'
       region: content
+    group_settings:
+      children:
+        - field_course_section_redirect
+        - status
+      format_settings:
+        classes: social-collapsible-fieldset
+        description: ''
+        id: ''
+        open: false
+        required_fields: true
+      format_type: details
+      label: Settings
+      parent_name: ''
+      region: hidden
+      weight: 20
+    group_access_permissions:
+      children:
+        - groups
+      format_settings:
+        classes: ''
+        description: ''
+        id: ''
+        required_fields: true
+      format_type: fieldset
+      label: 'Access permissions'
+      parent_name: ''
+      region: content
+      weight: 0
 id: node.course_section.default
 targetEntityType: node
 bundle: course_section

--- a/config/update/social_course_update_8010.yml
+++ b/config/update/social_course_update_8010.yml
@@ -1,0 +1,40 @@
+core.entity_form_display.node.course_section.default:
+  expected_config: { }
+  update_actions:
+    delete: {}
+    add:
+      third_party_settings:
+        field_group:
+          group_settings:
+            children:
+              - field_course_section_redirect
+              - status
+            format_settings:
+              classes: social-collapsible-fieldset
+              description: ''
+              id: ''
+              open: false
+              required_fields: true
+            format_type: details
+            label: Settings
+            parent_name: ''
+            region: hidden
+            weight: 20
+          group_access_permissions:
+            children:
+              - groups
+            format_settings:
+              classes: ''
+              description: ''
+              id: ''
+              required_fields: true
+            format_type: fieldset
+            label: 'Access permissions'
+            parent_name: ''
+            region: content
+            weight: 0
+    change:
+      third_party_settings:
+        field_group:
+          group_section_content:
+            label: 'Basic information'

--- a/config/update/social_course_update_8010.yml
+++ b/config/update/social_course_update_8010.yml
@@ -1,7 +1,9 @@
 core.entity_form_display.node.course_section.default:
   expected_config: { }
   update_actions:
-    delete: {}
+    delete:
+      hidden:
+        uid: true
     add:
       third_party_settings:
         field_group:

--- a/modules/social_course_advanced/config/install/core.entity_form_display.group.course_advanced.default.yml
+++ b/modules/social_course_advanced/config/install/core.entity_form_display.group.course_advanced.default.yml
@@ -71,17 +71,17 @@ third_party_settings:
         - field_course_opening_date
       parent_name: group_settings'
       weight: 1
-      format_type: fieldset
+      format_type: details
       format_settings:
         id: ''
         classes: ''
         description: ''
         required_fields: true
-      label: 'Date and Time'
+      label: 'Course starting time'
       region: content
     group_additional_details:
       children:
-        - group_related_courses
+        - field_course_related_courses
       parent_name: ''
       weight: 2
       format_type: details
@@ -119,7 +119,7 @@ content:
     type: link_default
     region: content
   field_course_related_courses:
-    weight: 4
+    weight: 51
     settings:
       match_operator: CONTAINS
       size: 60

--- a/modules/social_course_advanced/config/install/core.entity_form_display.group.course_advanced.default.yml
+++ b/modules/social_course_advanced/config/install/core.entity_form_display.group.course_advanced.default.yml
@@ -34,27 +34,29 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Information
+      label: 'Basic information'
       region: content
     group_settings:
       children:
+        - group_date_and_time
         - field_course_order
         - status
         - field_course_redirect_url
       parent_name: ''
       weight: 3
-      format_type: fieldset
+      format_type: details
       format_settings:
-        id: ''
-        classes: ''
         description: ''
         required_fields: true
+        id: ''
+        classes: social-collapsible-fieldset
+        open: false
       label: Settings
       region: content
     group_related_courses:
       children:
         - field_course_related_courses
-      parent_name: ''
+      parent_name: group_additional_details'
       weight: 4
       format_type: fieldset
       format_settings:
@@ -67,7 +69,7 @@ third_party_settings:
     group_date_and_time:
       children:
         - field_course_opening_date
-      parent_name: ''
+      parent_name: group_settings'
       weight: 1
       format_type: fieldset
       format_settings:
@@ -77,6 +79,20 @@ third_party_settings:
         required_fields: true
       label: 'Date and Time'
       region: content
+    group_additional_details:
+      children:
+        - group_related_courses
+      parent_name: ''
+      weight: 2
+      format_type: details
+      region: content
+      format_settings:
+        id: ''
+        classes: social-collapsible-fieldset
+        description: ''
+        open: false
+        required_fields: true
+      label: 'Additional information'
 id: group.course_advanced.default
 targetEntityType: group
 bundle: course_advanced
@@ -115,10 +131,10 @@ content:
     weight: 0
     settings: {  }
     third_party_settings: {  }
-    type: options_select
+    type: options_buttons
     region: content
   field_group_description:
-    weight: 2
+    weight: 7
     settings:
       rows: 5
       placeholder: ''
@@ -126,7 +142,7 @@ content:
     type: text_textarea
     region: content
   field_group_image:
-    weight: 3
+    weight: 6
     settings:
       show_crop_area: true
       show_default_crop: true

--- a/modules/social_course_advanced/config/install/field.field.group.course_advanced.field_course_redirect_url.yml
+++ b/modules/social_course_advanced/config/install/field.field.group.course_advanced.field_course_redirect_url.yml
@@ -10,7 +10,7 @@ id: group.course_advanced.field_course_redirect_url
 field_name: field_course_redirect_url
 entity_type: group
 bundle: course_advanced
-label: 'Redirect URL'
+label: 'Course completion page'
 description: 'The URL where user will be redirected when he finished the course.'
 required: false
 translatable: false

--- a/modules/social_course_advanced/config/update/social_course_advanced_update_8001.yml
+++ b/modules/social_course_advanced/config/update/social_course_advanced_update_8001.yml
@@ -1,0 +1,51 @@
+core.entity_form_display.group.course_advanced.default:
+  expected_config: {}
+  update_actions:
+    delete: {}
+    add:
+      third_party_settings:
+        field_group:
+          group_additional_details:
+            children:
+              - group_related_courses
+            format_settings:
+              classes: social-collapsible-fieldset
+              description: ''
+              id: ''
+              open: false
+              required_fields: true
+            format_type: details
+            label: 'Additional information'
+            parent_name: ''
+            region: content
+            weight: 2
+          group_settings:
+            children:
+              - group_date_and_time
+            format_settings:
+              open: false
+    change:
+      content:
+        field_course_order:
+          weight: 3
+        field_course_redirect_url:
+          weight: 4
+        field_course_type:
+          type: options_buttons
+        field_group_description:
+          weight: 7
+        field_group_image:
+          weight: 6
+      third_party_settings:
+        field_group:
+          group_date_and_time:
+            parent_name: group_settings
+            weight: 2
+          group_related_courses:
+            parent_name: group_additional_details
+          group_settings:
+            format_settings:
+              classes: social-collapsible-fieldset
+            format_type: details
+          group_information:
+            label: 'Basic information'

--- a/modules/social_course_advanced/config/update/social_course_advanced_update_8001.yml
+++ b/modules/social_course_advanced/config/update/social_course_advanced_update_8001.yml
@@ -1,8 +1,24 @@
 core.entity_form_display.group.course_advanced.default:
   expected_config: {}
   update_actions:
-    delete: {}
+    delete:
+      hidden:
+        field_flexible_group_visibility: true
+        field_group_allowed_visibility: true
     add:
+      content:
+        field_flexible_group_visibility:
+          region: content
+          settings: { }
+          third_party_settings: { }
+          type: options_buttons
+          weight: 100
+        field_group_allowed_visibility:
+          weight: 101
+          settings: { }
+          third_party_settings: { }
+          type: options_buttons
+          region: content
       third_party_settings:
         field_group:
           group_additional_details:
@@ -19,6 +35,20 @@ core.entity_form_display.group.course_advanced.default:
             parent_name: ''
             region: content
             weight: 2
+          group_access_permissions:
+            children:
+              - field_flexible_group_visibility
+              - field_group_allowed_visibility
+            format_settings:
+              classes: ''
+              description: ''
+              id: ''
+              required_fields: true
+            format_type: fieldset
+            label: 'Access permissions'
+            parent_name: ''
+            region: content
+            weight: 1
           group_settings:
             children:
               - group_date_and_time

--- a/modules/social_course_advanced/config/update/social_course_advanced_update_8001.yml
+++ b/modules/social_course_advanced/config/update/social_course_advanced_update_8001.yml
@@ -1,7 +1,12 @@
 core.entity_form_display.group.course_advanced.default:
-  expected_config: {}
+  expected_config: { }
   update_actions:
     delete:
+      third_party_settings:
+        field_group:
+          group_related_courses:
+            children:
+              - field_course_related_courses
       hidden:
         field_flexible_group_visibility: true
         field_group_allowed_visibility: true
@@ -23,7 +28,7 @@ core.entity_form_display.group.course_advanced.default:
         field_group:
           group_additional_details:
             children:
-              - group_related_courses
+              - field_course_related_courses
             format_settings:
               classes: social-collapsible-fieldset
               description: ''
@@ -66,16 +71,23 @@ core.entity_form_display.group.course_advanced.default:
           weight: 7
         field_group_image:
           weight: 6
+        field_course_related_courses:
+          weight: 51
       third_party_settings:
         field_group:
-          group_date_and_time:
-            parent_name: group_settings
-            weight: 2
-          group_related_courses:
-            parent_name: group_additional_details
           group_settings:
             format_settings:
               classes: social-collapsible-fieldset
             format_type: details
           group_information:
             label: 'Basic information'
+          group_date_and_time:
+            parent_name: group_settings
+            format_type: details
+            label: 'Course starting time'
+field.field.group.course_advanced.field_course_redirect_url:
+  expected_config: { }
+  update_actions:
+    change:
+      label: 'Course completion page'
+

--- a/modules/social_course_advanced/social_course_advanced.install
+++ b/modules/social_course_advanced/social_course_advanced.install
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * The Social Course Advanced (de)installation file.
+ */
+
+/**
+ * Configuration update: change form display.
+ */
+function social_course_advanced_update_8001() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_course_advanced', 'social_course_advanced_update_8001');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/modules/social_course_basic/config/install/core.entity_form_display.group.course_basic.default.yml
+++ b/modules/social_course_basic/config/install/core.entity_form_display.group.course_basic.default.yml
@@ -34,27 +34,29 @@ third_party_settings:
         classes: ''
         description: ''
         required_fields: true
-      label: Information
+      label: 'Basic information'
       region: content
     group_settings:
       children:
+        - group_date_and_time
         - field_course_order
         - status
         - field_course_redirect_url
       parent_name: ''
       weight: 3
-      format_type: fieldset
+      format_type: details
       format_settings:
-        id: ''
-        classes: ''
         description: ''
         required_fields: true
+        id: ''
+        classes: social-collapsible-fieldset
+        open: false
       label: Settings
       region: content
     group_related_courses:
       children:
         - field_course_related_courses
-      parent_name: ''
+      parent_name: group_additional_details
       weight: 4
       format_type: fieldset
       format_settings:
@@ -67,7 +69,7 @@ third_party_settings:
     group_date_and_time:
       children:
         - field_course_opening_date
-      parent_name: ''
+      parent_name: group_settings
       weight: 1
       format_type: fieldset
       format_settings:
@@ -77,6 +79,20 @@ third_party_settings:
         required_fields: true
       label: 'Date and Time'
       region: content
+    group_additional_details:
+      children:
+        - group_related_courses
+      parent_name: ''
+      weight: 2
+      format_type: details
+      region: content
+      format_settings:
+        id: ''
+        classes: social-collapsible-fieldset
+        description: ''
+        open: false
+        required_fields: true
+      label: 'Additional information'
 id: group.course_basic.default
 targetEntityType: group
 bundle: course_basic
@@ -115,10 +131,10 @@ content:
     weight: 4
     settings: {  }
     third_party_settings: {  }
-    type: options_select
+    type: options_buttons
     region: content
   field_group_description:
-    weight: 6
+    weight: 7
     settings:
       rows: 5
       placeholder: ''
@@ -126,7 +142,7 @@ content:
     type: text_textarea
     region: content
   field_group_image:
-    weight: 7
+    weight: 6
     settings:
       show_crop_area: true
       show_default_crop: true

--- a/modules/social_course_basic/config/install/core.entity_form_display.group.course_basic.default.yml
+++ b/modules/social_course_basic/config/install/core.entity_form_display.group.course_basic.default.yml
@@ -54,9 +54,7 @@ third_party_settings:
       label: Settings
       region: content
     group_related_courses:
-      children:
-        - field_course_related_courses
-      parent_name: group_additional_details
+      parent_name: ''
       weight: 4
       format_type: fieldset
       format_settings:
@@ -71,17 +69,17 @@ third_party_settings:
         - field_course_opening_date
       parent_name: group_settings
       weight: 1
-      format_type: fieldset
+      format_type: details
       format_settings:
         id: ''
         classes: ''
         description: ''
         required_fields: true
-      label: 'Date and Time'
+      label: 'Course starting time'
       region: content
     group_additional_details:
       children:
-        - group_related_courses
+        - field_course_related_courses
       parent_name: ''
       weight: 2
       format_type: details
@@ -119,7 +117,7 @@ content:
     type: link_default
     region: content
   field_course_related_courses:
-    weight: 4
+    weight: 51
     settings:
       match_operator: CONTAINS
       size: 60

--- a/modules/social_course_basic/config/install/field.field.group.course_basic.field_course_redirect_url.yml
+++ b/modules/social_course_basic/config/install/field.field.group.course_basic.field_course_redirect_url.yml
@@ -10,7 +10,7 @@ id: group.course_basic.field_course_redirect_url
 field_name: field_course_redirect_url
 entity_type: group
 bundle: course_basic
-label: 'Redirect URL'
+label: 'Course completion page'
 description: 'The URL where user will be redirected when he finished the course.'
 required: false
 translatable: true

--- a/modules/social_course_basic/config/update/social_course_basic_update_8001.yml
+++ b/modules/social_course_basic/config/update/social_course_basic_update_8001.yml
@@ -1,7 +1,12 @@
 core.entity_form_display.group.course_basic.default:
-  expected_config: {}
+  expected_config: { }
   update_actions:
     delete:
+      third_party_settings:
+        field_group:
+          group_related_courses:
+            children:
+              - field_course_related_courses
       hidden:
         field_flexible_group_visibility: true
         field_group_allowed_visibility: true
@@ -23,7 +28,7 @@ core.entity_form_display.group.course_basic.default:
         field_group:
           group_additional_details:
             children:
-              - group_related_courses
+              - field_course_related_courses
             format_settings:
               classes: social-collapsible-fieldset
               description: ''
@@ -66,16 +71,22 @@ core.entity_form_display.group.course_basic.default:
           weight: 7
         field_group_image:
           weight: 6
+        field_course_related_courses:
+          weight: 51
       third_party_settings:
         field_group:
-          group_date_and_time:
-            parent_name: group_settings
-            weight: 2
-          group_related_courses:
-            parent_name: group_additional_details
           group_settings:
             format_settings:
               classes: social-collapsible-fieldset
             format_type: details
           group_information:
             label: 'Basic information'
+          group_date_and_time:
+            parent_name: group_settings
+            format_type: details
+            label: 'Course starting time'
+field.field.group.course_basic.field_course_redirect_url:
+  expected_config: { }
+  update_actions:
+    change:
+      label: 'Course completion page'

--- a/modules/social_course_basic/config/update/social_course_basic_update_8001.yml
+++ b/modules/social_course_basic/config/update/social_course_basic_update_8001.yml
@@ -1,0 +1,51 @@
+core.entity_form_display.group.course_basic.default:
+  expected_config: {}
+  update_actions:
+    delete: {}
+    add:
+      third_party_settings:
+        field_group:
+          group_additional_details:
+            children:
+              - group_related_courses
+            format_settings:
+              classes: social-collapsible-fieldset
+              description: ''
+              id: ''
+              open: false
+              required_fields: true
+            format_type: details
+            label: 'Additional information'
+            parent_name: ''
+            region: content
+            weight: 2
+          group_settings:
+            children:
+              - group_date_and_time
+            format_settings:
+              open: false
+    change:
+      content:
+        field_course_order:
+          weight: 3
+        field_course_redirect_url:
+          weight: 4
+        field_course_type:
+          type: options_buttons
+        field_group_description:
+          weight: 7
+        field_group_image:
+          weight: 6
+      third_party_settings:
+        field_group:
+          group_date_and_time:
+            parent_name: group_settings
+            weight: 2
+          group_related_courses:
+            parent_name: group_additional_details
+          group_settings:
+            format_settings:
+              classes: social-collapsible-fieldset
+            format_type: details
+          group_information:
+            label: 'Basic information'

--- a/modules/social_course_basic/config/update/social_course_basic_update_8001.yml
+++ b/modules/social_course_basic/config/update/social_course_basic_update_8001.yml
@@ -1,8 +1,24 @@
 core.entity_form_display.group.course_basic.default:
   expected_config: {}
   update_actions:
-    delete: {}
+    delete:
+      hidden:
+        field_flexible_group_visibility: true
+        field_group_allowed_visibility: true
     add:
+      content:
+        field_flexible_group_visibility:
+          region: content
+          settings: { }
+          third_party_settings: { }
+          type: options_buttons
+          weight: 100
+        field_group_allowed_visibility:
+          weight: 101
+          settings: { }
+          third_party_settings: { }
+          type: options_buttons
+          region: content
       third_party_settings:
         field_group:
           group_additional_details:
@@ -19,6 +35,20 @@ core.entity_form_display.group.course_basic.default:
             parent_name: ''
             region: content
             weight: 2
+          group_access_permissions:
+            children:
+              - field_flexible_group_visibility
+              - field_group_allowed_visibility
+            format_settings:
+              classes: ''
+              description: ''
+              id: ''
+              required_fields: true
+            format_type: fieldset
+            label: 'Access permissions'
+            parent_name: ''
+            region: content
+            weight: 1
           group_settings:
             children:
               - group_date_and_time

--- a/modules/social_course_basic/social_course_basic.install
+++ b/modules/social_course_basic/social_course_basic.install
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * The Social Course Basic (de)installation file.
+ */
+
+/**
+ * Configuration update: change form display.
+ */
+function social_course_basic_update_8001() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_course_basic', 'social_course_basic_update_8001');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/social_course.install
+++ b/social_course.install
@@ -360,3 +360,16 @@ function social_course_update_8009() {
   }
 }
 
+/**
+ * Configuration update: change Course Section form display.
+ */
+function social_course_update_8010() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('social_course', 'social_course_update_8010');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/social_course.module
+++ b/social_course.module
@@ -596,7 +596,7 @@ function social_course_form_alter(&$form, FormStateInterface $form_state, $form_
       $form['field_course_opening_date_status'] = [
         '#type' => 'checkbox',
         '#weight' => -1,
-        '#title' => t('Enable open date and time'),
+        '#title' => t('Set starting date and time'),
         '#description' => t("When enabled, course sections and other information can only be accessed by members after the course starts. Enrolment can only take place before the course has started.
 <br>When not enabled, course sections and other information can be accessed right after enrolment."),
         '#default_value' => !empty($form['field_course_opening_date']['widget'][0]['value']['#default_value']),

--- a/social_course.module
+++ b/social_course.module
@@ -816,6 +816,11 @@ function social_course_form_node_form_alter(&$form, FormStateInterface $form_sta
           unset($form['groups']['widget']['#options'][$key]);
         }
       }
+
+      // Change field groups title for course section node.
+      if (isset($form['groups']['widget']['#options'])) {
+        $form['groups']['widget']['#title'] = t('Course');
+      }
     }
   }
 }
@@ -1864,3 +1869,12 @@ function social_course_cron() {
     }
   }
 }
+
+/**
+ * Implements hook_social_core_compatible_content_forms_alter().
+ */
+function social_course_social_core_compatible_content_forms_alter(&$compatible_content_type_forms) {
+  $compatible_content_type_forms[] = 'node_course_section_form';
+  $compatible_content_type_forms[] = 'node_course_section_edit_form';
+}
+


### PR DESCRIPTION
## Problem

- Implement new design for basic and advanced courses
- Add dependency from OS 10.x
- 'Finish destination' to be renamed to “Cours completion page”

## Issue tracker
- https://www.drupal.org/project/social_course/issues/3200126
- https://getopensocial.atlassian.net/browse/YANG-4513

## How to test
Go to the course create an or edit page.