### PR TITLE
Issue #3202479 by vnech: Allow to extend course material types list in ContentAccessCheck

### DIFF
--- a/src/Access/ContentAccessCheck.php
+++ b/src/Access/ContentAccessCheck.php
@@ -20,9 +20,9 @@ class ContentAccessCheck extends NodeAddAccessCheck {
   public function access(AccountInterface $account, NodeTypeInterface $node_type = NULL) {
     $forbidden = ['course_article', 'course_section', 'course_video'];
 
-		// Allow other modules to register their own types.
-		\Drupal::moduleHandler()
-			->alter('social_course_material_types', $forbidden);
+    // Allow other modules to register their own types.
+    \Drupal::moduleHandler()
+      ->alter('social_course_material_types', $forbidden);
 
     if (in_array($node_type->id(), $forbidden)) {
       return AccessResult::forbidden();

--- a/src/Access/ContentAccessCheck.php
+++ b/src/Access/ContentAccessCheck.php
@@ -20,6 +20,10 @@ class ContentAccessCheck extends NodeAddAccessCheck {
   public function access(AccountInterface $account, NodeTypeInterface $node_type = NULL) {
     $forbidden = ['course_article', 'course_section', 'course_video'];
 
+		// Allow other modules to register their own types.
+		\Drupal::moduleHandler()
+			->alter('social_course_material_types', $forbidden);
+
     if (in_array($node_type->id(), $forbidden)) {
       return AccessResult::forbidden();
     }


### PR DESCRIPTION
## Problem
Users should be able to extend course material types list for handling access

## Issue tracker
- https://www.drupal.org/project/social_course/issues/3202479
- https://getopensocial.atlassian.net/browse/ECI-1131

## How to test
- Enable "Social Course Quiz" extention;
- Visit _/node/add/course_quiz_ page (you should get "access denie")